### PR TITLE
Move test import to RunTest class

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -8,8 +8,6 @@ try:
     import unittest2 as unittest
 except ImportError:
     import unittest
-from tests import maintest
-from tests import deprecationtest
 
 class RunTests(Command):
 
@@ -30,8 +28,9 @@ class RunTests(Command):
             print('╰─────────────────────────────────────╯')
         else:
             print('Test Start')
-        import tests
-        testSuite = unittest.TestSuite(tests.testsuite())
+        from tests import maintest
+        from tests import deprecationtest
+        testSuite = unittest.TestSuite(testsuite())
         runner = unittest.TextTestRunner(verbosity=2)
         results = runner.run(testSuite)
         sys.exit(0 if results.wasSuccessful() else 1)


### PR DESCRIPTION
Cannot install via pip due to below error so moved import statement. Also removed self import.

```
PS D:\Users\...\pypreprocessor\tests\.isolated> pip install pypreprocessor
Collecting pypreprocessor
  Using cached pypreprocessor-0.7.7.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "c:\users\...\pip-build-lrqpqz\pypreprocessor\setup.py", line 16, in <module>
        from tests import RunTests
      File "tests\__init__.py", line 11, in <module>
        from tests import maintest
    ImportError: cannot import name maintest

    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in c:\users\...\temp\pip-build-lrqpqz\pypreprocessor\
```


