### PR TITLE
Fixed wrong stack trace dump

### DIFF
--- a/pypreprocessor/__init__.py
+++ b/pypreprocessor/__init__.py
@@ -237,11 +237,7 @@ class preprocessor:
         trace = traceback.format_exc().splitlines()
         index = 0
         for line in trace:
-            if index == (len(trace) - 2):
-                print(line.replace("<string>", self.input))
-            else:
-                print(line)
-            index += 1
+            print(line.replace("\"<string>\"", self.input))
 
     # parsing/processing
     def parse(self):


### PR DESCRIPTION
-The function rewrite_traceback() assumes erroneously a fixed frame
 introducing the file name in the stack trace in case of exceptions
 during execution of the input file. This limition is removed with this
 patch so that all sizes of call stacks will be treated correctly.